### PR TITLE
Add Kutt provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ With authentication:
 
 - `goo.gl`
 - `bit.ly`
+- `kutt.it` (supports self hosting)
 
 Without authentication:
 

--- a/examples/via_kutt_custom_host_provider.rs
+++ b/examples/via_kutt_custom_host_provider.rs
@@ -1,0 +1,23 @@
+//! Generate a short URL by specifying which provider to use.
+
+extern crate urlshortener;
+
+use urlshortener::client::UrlShortener;
+use urlshortener::providers::Provider;
+
+fn main() {
+    let long_url = "https://doc.rust-lang.org/std/";
+
+    let us = UrlShortener::new().unwrap();
+    let key = "MY_API_KEY";
+    let host = "https://example.com";
+    let short_url = us.generate(
+        long_url,
+        &Provider::Kutt {
+            api_key: key.into(),
+            host: Some(host.into()),
+        },
+    );
+
+    println!("{:?}", short_url);
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "client")]
-use reqwest::{header, Client, Response};
+use reqwest::{
+    header::{self, HeaderMap},
+    Client, Response,
+};
 
 const CONTENT_JSON: &str = "application/json";
 const CONTENT_FORM_URL_ENCODED: &str = "application/x-www-form-urlencoded";
@@ -37,6 +40,8 @@ pub struct Request {
     pub content_type: Option<ContentType>,
     /// The user agent.
     pub user_agent: Option<UserAgent>,
+    /// Request headers.
+    pub headers: Option<HeaderMap>,
     /// The HTTP method.
     pub method: Method,
 }
@@ -52,6 +57,10 @@ impl Request {
 
         if let Some(agent) = self.user_agent.clone() {
             builder = builder.header(header::USER_AGENT, agent.0);
+        }
+
+        if let Some(headers) = self.headers.clone() {
+            builder = builder.headers(headers);
         }
 
         if let Some(content_type) = self.content_type {


### PR DESCRIPTION
This PR adds the `kutt.it` provider.

It supports custom hosts through an optional `host` field. 

The provider definition looks like this:

https://github.com/vityafx/urlshortener-rs/blob/c3dd0fcc7c31659e4833cfab454c6841178d2fff/src/providers.rs#L170-L176

Please note that I've added a `headers` field to the `Request` object, because a `kutt.it` request needs to have an API key header set. This somewhat overlaps with the `user_agent` field.

Fixes #16